### PR TITLE
Fixed js scripts not loading on posts links

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,8 +1,8 @@
 <!-- Scripts -->
-<script src="js/jquery.min.js"></script>
-<script src="js/jquery.scrollex.min.js"></script>
-<script src="js/jquery.scrolly.min.js"></script>
-<script src="js/skel.min.js"></script>
-<script src="js/util.js"></script>
-<!--[if lte IE 8]><script src="js/ie/respond.min.js"></script><![endif]-->
-<script src="js/main.js"></script>
+<script src="{{ "/js/jquery.min.js" | prepend: site.baseurl }}"></script>
+<script src="{{ "/js/jquery.scrollex.min.js" | prepend: site.baseurl }}"></script>
+<script src="{{ "/js/jquery.scrolly.min.js" | prepend: site.baseurl }}"></script>
+<script src="{{ "/js/skel.min.js" | prepend: site.baseurl }}"></script>
+<script src="{{ "/js/util.js" | prepend: site.baseurl }}"></script>
+<!--[if lte IE 8]><script src="{{ "/js/ie/respond.min.js" | prepend: site.baseurl }}"></script><![endif]-->
+<script src="{{ "/js/main.js" | prepend: site.baseurl }}"></script>


### PR DESCRIPTION
On urls like http://example.com/category/post.html, 

``` html
<script src="js/jquery.min.js"></script>
```

tries to load js from http://example.com/category/js/jquery.min.js and we get a 404  
This fix loads js files the same way css files are loaded, also for consistency.
